### PR TITLE
Quiet down the javadoc plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -160,10 +160,11 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>3.1.0</version>
-                <!-- workaround for https://bugs.openjdk.java.net/browse/JDK-8212233 -->
-                <!--                <configuration>-->
-                <!--                    <source>8</source>-->
-                <!--                </configuration>-->
+                <configuration>
+                    <quiet>true</quiet>
+                    <!--                    workaround for https://bugs.openjdk.java.net/browse/JDK-8212233-->
+                    <!--                    <source>8</source>-->
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>


### PR DESCRIPTION
Suppress non-warning and non-error output to make the build log cleaner.