### PR TITLE
Reassign jobs on slave disconnect

### DIFF
--- a/src/main/java/io/github/incplusplus/peerprocessing/client/Client.java
+++ b/src/main/java/io/github/incplusplus/peerprocessing/client/Client.java
@@ -213,7 +213,7 @@ public class Client implements ProperClient, Personable {
 						disconnect();
 					}
 					catch (IOException ex) {
-						debug("There was an exception during the disconnect which began due to a previous exception!");
+						error("There was an exception during the disconnect which began due to a previous exception!");
 						printStackTrace(ex);
 					}
 					break;

--- a/src/main/java/io/github/incplusplus/peerprocessing/logger/StupidSimpleLogger.java
+++ b/src/main/java/io/github/incplusplus/peerprocessing/logger/StupidSimpleLogger.java
@@ -7,83 +7,90 @@ import java.io.PrintWriter;
 import java.io.StringWriter;
 
 public class StupidSimpleLogger {
-	private static boolean enabled;
-	private final static ColoredPrinter cp = new ColoredPrinter.Builder(1, false)
-			.foreground(Ansi.FColor.WHITE).background(Ansi.BColor.BLUE)   //setting format
-			.build();
-	
-	public static void enable() {
-		enabled = true;
-	}
-	
-	@SuppressWarnings("unused")
-	public static boolean isEnabled() {
-		return enabled;
-	}
-	
-	@SuppressWarnings("unused")
-	public static void disable() {
-		enabled = false;
-	}
-	
-	public synchronized static void debug(String message) {
-		if (enabled) {
-			synchronized (cp){
-				cp.clear();
-				cp.print("[" + cp.getDateFormatted() + "]", Ansi.Attribute.NONE, Ansi.FColor.CYAN, Ansi.BColor.BLACK);
-				cp.debugPrintln(" " + message);
-				cp.clear();
-			}
-		}
-	}
-	
-	public static void info(String message) {
-		if (enabled) {
-			synchronized (cp) {
-				cp.clear();
-				cp.println(message, Ansi.Attribute.NONE, Ansi.FColor.GREEN, Ansi.BColor.BLACK);
-				cp.clear();
-			}
-		}
-	}
-	
-	/**
-	 * Same as {@link #info(String)} but without printing linefeed afterwards.
-	 * @param message the message to print.
-	 */
-	public static void infoNoLine(String message) {
-		if (enabled) {
-			synchronized (cp) {
-				cp.clear();
-				//See https://github.com/dialex/JCDP/issues/21
-				cp.print("", Ansi.Attribute.NONE, Ansi.FColor.GREEN, Ansi.BColor.BLACK);
-				System.out.print(message);
-				cp.clear();
-			}
-		}
-	}
+  private static boolean enabled;
+  private static final ColoredPrinter cp =
+      new ColoredPrinter.Builder(1, false)
+          .foreground(Ansi.FColor.WHITE)
+          .background(Ansi.BColor.BLUE) // setting format
+          .build();
 
-	/** Super buggy at the moment. Don't use */
-	public static void error(String message) {
-		if (enabled) {
-			synchronized (cp) {
-				cp.clear();
-				cp.print("[" + cp.getDateFormatted() + "]", Ansi.Attribute.NONE, Ansi.FColor.CYAN, Ansi.BColor.BLACK);
-				cp.errorPrintln(" " + message, Ansi.Attribute.NONE, Ansi.FColor.CYAN, Ansi.BColor.BLACK);
-				cp.clear();
-			}
-		}
-	}
-	
-	public static void printStackTrace(Exception e) {
-		if (enabled) {
-			synchronized (cp) {
-				StringWriter errors = new StringWriter();
-				e.printStackTrace(new PrintWriter(errors));
-				cp.clear();
-				cp.errorPrint(errors.toString(), Ansi.Attribute.NONE, Ansi.FColor.CYAN, Ansi.BColor.BLACK);
-				cp.clear();
-			}
-		}
-	}
+  public static void enable() {
+    enabled = true;
+  }
+
+  @SuppressWarnings("unused")
+  public static boolean isEnabled() {
+    return enabled;
+  }
+
+  @SuppressWarnings("unused")
+  public static void disable() {
+    enabled = false;
+  }
+
+  public static synchronized void debug(String message) {
+    if (enabled) {
+      synchronized (cp) {
+        cp.clear();
+        cp.print(
+            "[" + cp.getDateFormatted() + "]",
+            Ansi.Attribute.NONE,
+            Ansi.FColor.CYAN,
+            Ansi.BColor.BLACK);
+        cp.debugPrintln(" " + message);
+        cp.clear();
+      }
+    }
+  }
+
+  public static void info(String message) {
+    if (enabled) {
+      synchronized (cp) {
+        cp.clear();
+        cp.println(message, Ansi.Attribute.NONE, Ansi.FColor.GREEN, Ansi.BColor.BLACK);
+        cp.clear();
+      }
+    }
+  }
+
+  /**
+   * Same as {@link #info(String)} but without printing linefeed afterwards.
+   *
+   * @param message the message to print.
+   */
+  public static void infoNoLine(String message) {
+    if (enabled) {
+      synchronized (cp) {
+        cp.clear();
+        // See https://github.com/dialex/JCDP/issues/21
+        cp.print("", Ansi.Attribute.NONE, Ansi.FColor.GREEN, Ansi.BColor.BLACK);
+        System.out.print(message);
+        cp.clear();
+      }
+    }
+  }
+
+  /** Super buggy at the moment. Don't use */
+  public static void error(String message) {
+    synchronized (cp) {
+      cp.clear();
+      cp.print(
+          "[" + cp.getDateFormatted() + "]",
+          Ansi.Attribute.NONE,
+          Ansi.FColor.CYAN,
+          Ansi.BColor.BLACK);
+      cp.errorPrintln(" " + message, Ansi.Attribute.NONE, Ansi.FColor.CYAN, Ansi.BColor.BLACK);
+      cp.clear();
+    }
+  }
+
+  public static void printStackTrace(Exception e) {
+    synchronized (cp) {
+      StringWriter errors = new StringWriter();
+      e.printStackTrace(new PrintWriter(errors));
+      cp.clear();
+      cp.errorPrint(errors.toString(), Ansi.Attribute.NONE, Ansi.FColor.CYAN, Ansi.BColor.BLACK);
+      cp.clear();
+    }
+  }
 }

--- a/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
+++ b/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
@@ -367,11 +367,12 @@ public class Server {
 		//just because it's a ConcurrentHashMap doesn't mean everything is safe!
 		synchronized (slaves) {
 			leastBusySlave = slaves.entrySet().parallelStream()
+					.map(Map.Entry::getValue)
 					//find the slave that is responsible for the fewest jobs
-					.min(Comparator.comparingInt(mapEntry -> mapEntry.getValue().getJobsResponsibleFor().size()))
-					//get the actual SlaveObj from the MapEntry<UUID, SlaveObj> or else
+					.min(Comparator.comparingInt(slaveObj -> slaveObj.getJobsResponsibleFor().size()))
+					//get the actual SlaveObj or else
 					//commit suicide
-					.map(Map.Entry::getValue).orElseThrow();
+					.orElseThrow();
 		}
 		job.setSolvingSlaveUUID(leastBusySlave.getConnectionUUID());
 		debug("Sending query " + job.getQueryId() + " to slave " + leastBusySlave.getConnectionUUID());

--- a/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
+++ b/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
@@ -374,9 +374,15 @@ public class Server {
 					//commit suicide
 					.orElseThrow();
 		}
-		job.setSolvingSlaveUUID(leastBusySlave.getConnectionUUID());
-		debug("Sending query " + job.getQueryId() + " to slave " + leastBusySlave.getConnectionUUID());
-		leastBusySlave.accept(job);
+		//make sure they're still registered
+		if (slaves.containsKey(leastBusySlave.getConnectionUUID())) {
+			job.setSolvingSlaveUUID(leastBusySlave.getConnectionUUID());
+			debug("Sending query " + job.getQueryId() + " to slave " + leastBusySlave.getConnectionUUID());
+			leastBusySlave.accept(job);
+		}
+		else {
+			sendToLeastBusySlave(job);
+		}
 	}
 	
 	private void poisonJobIngestionThread() {

--- a/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
+++ b/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
@@ -45,7 +45,7 @@ public class Server {
 	private final AtomicBoolean started = new AtomicBoolean(false);
 	private final AtomicBoolean shutdownInProgress = new AtomicBoolean(false);
 	private final Map<UUID, ClientObj> clients = new ConcurrentHashMap<>();
-	private final Map<UUID, SlaveObj> slaves = new ConcurrentHashMap<>();
+	final Map<UUID, SlaveObj> slaves = new ConcurrentHashMap<>();
 	/**
 	 * Should probably be replaced with {@link Executors#newCachedThreadPool()} at some point.
 	 * Elements of this list exist while an incoming connection is established and are removed

--- a/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
+++ b/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
@@ -523,8 +523,6 @@ public class Server {
 			while (!getSocket().isClosed()) {
 				try {
 					lineFromSlave = getInFromClient().readLine();
-					if (isNull(lineFromSlave))
-						disconnect();
 					Header header = getHeader(lineFromSlave);
 					if (header.equals(RESULT)) {
 						Query completedQuery = SHARED_MAPPER.readValue(Objects.requireNonNull(decode(lineFromSlave)), Query.class);
@@ -550,6 +548,20 @@ public class Server {
 						//we don't want to write back
 						kill();
 						break;
+					}
+				}
+				catch (NullPointerException npe) {
+					try {
+						debug("Slave " + getConnectionUUID() + " violently disconnected.");
+						deRegister(this);
+						disconnect();
+					} catch (IOException e) {
+						try {
+							getSocket().close();
+						}
+						catch (IOException ex) {
+							ex.printStackTrace();
+						}
 					}
 				}
 				catch (SocketException e) {

--- a/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
+++ b/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
@@ -523,7 +523,14 @@ public class Server {
 			while (!getSocket().isClosed()) {
 				try {
 					lineFromSlave = getInFromClient().readLine();
-					Header header = getHeader(lineFromSlave);
+					Header header = null;
+					try {
+						header = getHeader(lineFromSlave);
+					}
+					catch (NullPointerException e) {
+						error("Got NPE when lineFromSlave='"+lineFromSlave+"'. Shutting down...");
+						continue;
+					}
 					if (header.equals(RESULT)) {
 						Query completedQuery = SHARED_MAPPER.readValue(Objects.requireNonNull(decode(lineFromSlave)), Query.class);
 						Query storedQuery = removeJob(completedQuery.getQueryId());

--- a/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
+++ b/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
@@ -234,7 +234,8 @@ public class Server {
 	 */
 	private void deRegister(ConnectedEntity connectedEntity) {
 		if (connectedEntity instanceof SlaveObj) {
-			slaves.remove(connectedEntity.getConnectionUUID());
+			SlaveObj shouldBeNonNull = slaves.remove(connectedEntity.getConnectionUUID());
+			assert nonNull(shouldBeNonNull);
 			//for each of the queries the slave was processing
 			for (UUID uuid : ((SlaveObj) connectedEntity).getJobsResponsibleFor()) {
 				//put them in the queue to get processed

--- a/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
+++ b/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
@@ -523,14 +523,7 @@ public class Server {
 			while (!getSocket().isClosed()) {
 				try {
 					lineFromSlave = getInFromClient().readLine();
-					Header header = null;
-					try {
-						header = getHeader(lineFromSlave);
-					}
-					catch (NullPointerException e) {
-						error("Got NPE when lineFromSlave='"+lineFromSlave+"'. Shutting down...");
-						continue;
-					}
+					Header header = getHeader(lineFromSlave);
 					if (header.equals(RESULT)) {
 						Query completedQuery = SHARED_MAPPER.readValue(Objects.requireNonNull(decode(lineFromSlave)), Query.class);
 						Query storedQuery = removeJob(completedQuery.getQueryId());

--- a/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
+++ b/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
@@ -238,6 +238,7 @@ public class Server {
 			//for each of the queries the slave was processing
 			for (UUID uuid : ((SlaveObj) connectedEntity).getJobsResponsibleFor()) {
 				//put them in the queue to get processed
+				debug("Slave " + connectedEntity.getConnectionUUID()+ " abandoned job " + uuid);
 				jobsAwaitingProcessing.add(queries.get(uuid));
 			}
 		}

--- a/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
+++ b/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
@@ -239,7 +239,8 @@ public class Server {
 			for (UUID uuid : ((SlaveObj) connectedEntity).getJobsResponsibleFor()) {
 				//put them in the queue to get processed
 				debug("Slave " + connectedEntity.getConnectionUUID()+ " abandoned job " + uuid);
-				jobsAwaitingProcessing.add(queries.get(uuid));
+				boolean abandonedJobAdded = jobsAwaitingProcessing.add(queries.get(uuid));
+				assert abandonedJobAdded;
 			}
 		}
 		else if (connectedEntity instanceof ClientObj) {

--- a/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
+++ b/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
@@ -23,8 +23,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static io.github.incplusplus.peerprocessing.common.Constants.SHARED_MAPPER;
 import static io.github.incplusplus.peerprocessing.common.Demands.IDENTIFY;
@@ -244,17 +242,12 @@ public class Server {
 				//noinspection StatementWithEmptyBody
 				while(nonNull(slaves.get(connectedEntity.getConnectionUUID()))) {}
 				//for each of the queries the slave was processing
-				//put them in the queue to get processed
-				debug("Slave " + connectedEntity.getConnectionUUID() + " abandoned jobs " +
-						Arrays.toString(((SlaveObj) connectedEntity).getJobsResponsibleFor().toArray()));
-				jobsAwaitingProcessing.addAll(
-						((SlaveObj) connectedEntity).getJobsResponsibleFor().stream()
-								.map(queries::get).collect(Collectors.toList()));
-//				for (UUID uuid : ((SlaveObj) connectedEntity).getJobsResponsibleFor()) {
-//					debug("Slave " + connectedEntity.getConnectionUUID()+ " abandoned job " + uuid);
-//					boolean abandonedJobAdded = jobsAwaitingProcessing.add(queries.get(uuid));
-//					assert abandonedJobAdded;
-//				}
+				for (UUID uuid : ((SlaveObj) connectedEntity).getJobsResponsibleFor()) {
+					//put them in the queue to get processed
+					debug("Slave " + connectedEntity.getConnectionUUID()+ " abandoned job " + uuid);
+					boolean abandonedJobAdded = jobsAwaitingProcessing.add(queries.get(uuid));
+					assert abandonedJobAdded;
+				}
 			}
 		}
 		else if (connectedEntity instanceof ClientObj) {
@@ -358,47 +351,32 @@ public class Server {
 			requestSource.acceptCompleted(query);
 		}
 	}
-
-	private void sendToLeastBusySlave(Query... jobs) throws InterruptedException, JsonProcessingException {
-		//if we sync on slaves but there aren't any anymore
-		//we want to re-run this method
-		boolean noSlavesAfterSync = false;
+	
+	private void sendToLeastBusySlave(Query job) throws InterruptedException, JsonProcessingException {
 		SlaveObj leastBusySlave;
 		while (slaves.size() < 1) {
-      debug(
-          "Tried to send job with id "
-              + Arrays.toString(Arrays.stream(jobs).map(Query::getQueryId).toArray())
-              + " to a slave. "
-              + "However, no slaves were available. Job queue thread sleeping.");
+			debug("Tried to send job with id " + job.getQueryId() + " to a slave. " +
+					"However, no slaves were available. Job queue thread sleeping.");
 			Thread.sleep(250);
 		}
-		//just because it's a ConcurrentHashMap doesn't mean everything is safe!
-		synchronized (slaves) {
-			//check again after sync
-			if (slaves.size() < 1) {
-				noSlavesAfterSync = true;
-			} else {
-				for (Query individualJob : jobs) {
-					leastBusySlave = slaves.entrySet().parallelStream()
-							.map(Map.Entry::getValue)
-							//find the slave that is responsible for the fewest jobs
-							.min(Comparator.comparingInt(slaveObj -> slaveObj.getJobsResponsibleFor().size()))
-							//get the actual SlaveObj or else
-							//commit suicide
-							.orElseThrow();
-					individualJob.setSolvingSlaveUUID(leastBusySlave.getConnectionUUID());
-					debug("Sending query " + individualJob.getQueryId() + " to slave " + leastBusySlave.getConnectionUUID());
-					leastBusySlave.accept(individualJob);
-				}
-			}
-		}
-		if (noSlavesAfterSync)
-			sendToLeastBusySlave(jobs);
 		/*
 		 * TODO: Determining the business of slaves is not yet implemented as the
 		 *  heartbeat system has not yet been implemented. For now this method
 		 *  just sends the job to the slave dealing with the fewest jobs.
 		 */
+		//just because it's a ConcurrentHashMap doesn't mean everything is safe!
+		synchronized (slaves) {
+			leastBusySlave = slaves.entrySet().parallelStream()
+					.map(Map.Entry::getValue)
+					//find the slave that is responsible for the fewest jobs
+					.min(Comparator.comparingInt(slaveObj -> slaveObj.getJobsResponsibleFor().size()))
+					//get the actual SlaveObj or else
+					//commit suicide
+					.orElseThrow();
+		}
+		job.setSolvingSlaveUUID(leastBusySlave.getConnectionUUID());
+		debug("Sending query " + job.getQueryId() + " to slave " + leastBusySlave.getConnectionUUID());
+		leastBusySlave.accept(job);
 	}
 	
 	private void poisonJobIngestionThread() {
@@ -423,40 +401,20 @@ public class Server {
 			}
 			while (started()) {
 				try {
-					List<Query> pendingJobs = new ArrayList<>();
-					//block on the call to take(). This is usually less intensive then
-					//repeatedly calling size() because that requires reentrant locks
-					pendingJobs.add(jobsAwaitingProcessing.take());
-					int obtainedJobs = jobsAwaitingProcessing.drainTo(pendingJobs);
-					List<PoisonPill> poisonPills = new ArrayList<>(1);
-					List<BatchQuery> batchQueries = new ArrayList<>();
-					List<Query> normalQueries = new ArrayList<>();
-					//iterate once over the pending jobs and get the various query types
-					pendingJobs.forEach(query -> {
-						if (query instanceof PoisonPill) {
-							poisonPills.add((PoisonPill) query);
-						}
-						else if (query instanceof BatchQuery) {
-							batchQueries.add((BatchQuery) query);
-						}
-						else {
-							normalQueries.add(query);
-						}
-					});
-					if (poisonPills.size() > 0) {
+					Query currentJob = jobsAwaitingProcessing.take();
+					if (currentJob instanceof PoisonPill) {
 						debug("Job ingestion thread ate a poison pill and is shutting down.");
 						break;
 					}
-					batchQueries.forEach(currentJob -> {
-						List<Query> childQueries = currentJob.getQueries();
+					if(currentJob instanceof BatchQuery) {
 						currentJob.setQueryState(WAITING_ON_SLAVE);
-						queries.putAll(childQueries
-								.stream()
-								.collect(Collectors.toMap(Query::getQueryId, Function.identity())));
-						jobsAwaitingProcessing.addAll(childQueries);
-					});
-					if (normalQueries.size() > 0) {
-						sendToLeastBusySlave(normalQueries.toArray(Query[]::new));
+						for(Query individualJob : ((BatchQuery) currentJob).getQueries()) {
+							queries.put(individualJob.getQueryId(),individualJob);
+							jobsAwaitingProcessing.add(individualJob);
+						}
+					}
+					else {
+						sendToLeastBusySlave(currentJob);
 					}
 				}
 				catch (InterruptedException | JsonProcessingException e) {

--- a/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
+++ b/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
@@ -523,6 +523,8 @@ public class Server {
 			while (!getSocket().isClosed()) {
 				try {
 					lineFromSlave = getInFromClient().readLine();
+					if (isNull(lineFromSlave))
+						disconnect();
 					Header header = getHeader(lineFromSlave);
 					if (header.equals(RESULT)) {
 						Query completedQuery = SHARED_MAPPER.readValue(Objects.requireNonNull(decode(lineFromSlave)), Query.class);

--- a/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
+++ b/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
@@ -353,19 +353,17 @@ public class Server {
 	}
 	
 	private void sendToLeastBusySlave(Query job) throws InterruptedException, JsonProcessingException {
+		SlaveObj leastBusySlave;
 		while (slaves.size() < 1) {
-			long NO_SLAVES_SLEEP_TIME = 1000 * 2;
 			debug("Tried to send job with id " + job.getQueryId() + " to a slave. " +
-					"However, no slaves were available. Job queue thread sleeping " +
-					"for " + NO_SLAVES_SLEEP_TIME / 1000 + " second(s)...");
-			Thread.sleep(NO_SLAVES_SLEEP_TIME);
+					"However, no slaves were available. Job queue thread sleeping.");
+			Thread.sleep(250);
 		}
 		/*
 		 * TODO: Determining the business of slaves is not yet implemented as the
 		 *  heartbeat system has not yet been implemented. For now this method
 		 *  just sends the job to the slave dealing with the fewest jobs.
 		 */
-		SlaveObj leastBusySlave;
 		//just because it's a ConcurrentHashMap doesn't mean everything is safe!
 		synchronized (slaves) {
 			leastBusySlave = slaves.entrySet().parallelStream()
@@ -421,6 +419,12 @@ public class Server {
 				}
 				catch (InterruptedException | JsonProcessingException e) {
 					printStackTrace(e);
+					try {
+						//If job ingestion thread dies, kill off server
+						this.stop();
+					} catch (IOException ex) {
+						ex.printStackTrace();
+					}
 				}
 			}
 		});

--- a/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
+++ b/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
@@ -234,8 +234,12 @@ public class Server {
 	 */
 	private void deRegister(ConnectedEntity connectedEntity) {
 		if (connectedEntity instanceof SlaveObj) {
-			//TODO add responsibility reassignment if the slave held jobs
 			slaves.remove(connectedEntity.getConnectionUUID());
+			//for each of the queries the slave was processing
+			for (UUID uuid : ((SlaveObj) connectedEntity).getJobsResponsibleFor()) {
+				//put them in the queue to get processed
+				jobsAwaitingProcessing.add(queries.get(uuid));
+			}
 		}
 		else if (connectedEntity instanceof ClientObj) {
 			clients.remove(connectedEntity.getConnectionUUID());

--- a/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
+++ b/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
@@ -349,7 +349,7 @@ public class Server {
 		/*
 		 * TODO: Determining the business of slaves is not yet implemented as the
 		 *  heartbeat system has not yet been implemented. For now this method
-		 *  just sends the job to a random slave.
+		 *  just sends the job to the slave dealing with the fewest jobs.
 		 */
 		//noinspection RedundantCast because if we don't cast, IntelliJ warns about suspicious call to Map.get()
 		SlaveObj designatedSlave = slaves.get((UUID) slaves.keySet().toArray()[randInt(0, slaves.size() - 1)]);

--- a/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
+++ b/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
@@ -597,7 +597,14 @@ public class Server {
 			query.setQueryState(WAITING_ON_SLAVE);
 			jobsResponsibleFor.add(query.getQueryId());
 			debug("Slave " + getConnectionUUID() + " now responsible for " + query.getQueryId());
-			getOutToClient().println(msg(SHARED_MAPPER.writeValueAsString(query), QUERY));
+			new Thread(() -> {
+				try {
+					getOutToClient().println(msg(SHARED_MAPPER.writeValueAsString(query), QUERY));
+				} catch (JsonProcessingException e) {
+					e.printStackTrace();
+				}
+			}).start();
+//			getOutToClient().println(msg(SHARED_MAPPER.writeValueAsString(query), QUERY));
 		}
 		
 		/**

--- a/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
+++ b/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
@@ -234,16 +234,18 @@ public class Server {
 	 */
 	private void deRegister(ConnectedEntity connectedEntity) {
 		if (connectedEntity instanceof SlaveObj) {
-			SlaveObj shouldBeNonNull = slaves.remove(connectedEntity.getConnectionUUID());
-			assert nonNull(shouldBeNonNull);
-			//noinspection StatementWithEmptyBody
-			while(nonNull(slaves.get(connectedEntity.getConnectionUUID()))) {}
-			//for each of the queries the slave was processing
-			for (UUID uuid : ((SlaveObj) connectedEntity).getJobsResponsibleFor()) {
-				//put them in the queue to get processed
-				debug("Slave " + connectedEntity.getConnectionUUID()+ " abandoned job " + uuid);
-				boolean abandonedJobAdded = jobsAwaitingProcessing.add(queries.get(uuid));
-				assert abandonedJobAdded;
+			synchronized (slaves) {
+				SlaveObj shouldBeNonNull = slaves.remove(connectedEntity.getConnectionUUID());
+				assert nonNull(shouldBeNonNull);
+				//noinspection StatementWithEmptyBody
+				while(nonNull(slaves.get(connectedEntity.getConnectionUUID()))) {}
+				//for each of the queries the slave was processing
+				for (UUID uuid : ((SlaveObj) connectedEntity).getJobsResponsibleFor()) {
+					//put them in the queue to get processed
+					debug("Slave " + connectedEntity.getConnectionUUID()+ " abandoned job " + uuid);
+					boolean abandonedJobAdded = jobsAwaitingProcessing.add(queries.get(uuid));
+					assert abandonedJobAdded;
+				}
 			}
 		}
 		else if (connectedEntity instanceof ClientObj) {

--- a/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
+++ b/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
@@ -597,14 +597,7 @@ public class Server {
 			query.setQueryState(WAITING_ON_SLAVE);
 			jobsResponsibleFor.add(query.getQueryId());
 			debug("Slave " + getConnectionUUID() + " now responsible for " + query.getQueryId());
-			new Thread(() -> {
-				try {
-					getOutToClient().println(msg(SHARED_MAPPER.writeValueAsString(query), QUERY));
-				} catch (JsonProcessingException e) {
-					e.printStackTrace();
-				}
-			}).start();
-//			getOutToClient().println(msg(SHARED_MAPPER.writeValueAsString(query), QUERY));
+			getOutToClient().println(msg(SHARED_MAPPER.writeValueAsString(query), QUERY));
 		}
 		
 		/**

--- a/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
+++ b/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
@@ -372,15 +372,22 @@ public class Server {
 					.min(Comparator.comparingInt(slaveObj -> slaveObj.getJobsResponsibleFor().size()))
 					//get the actual SlaveObj or else
 					//commit suicide
-					.orElseThrow();
+					.orElse(null);
 		}
-		//make sure they're still registered
-		if (slaves.containsKey(leastBusySlave.getConnectionUUID())) {
+		//if no slave ended up being found
+		if (isNull(leastBusySlave)) {
+			//try again
+			sendToLeastBusySlave(job);
+		}
+		//make sure they're still registered if present
+		else if (slaves.containsKey(leastBusySlave.getConnectionUUID())) {
 			job.setSolvingSlaveUUID(leastBusySlave.getConnectionUUID());
 			debug("Sending query " + job.getQueryId() + " to slave " + leastBusySlave.getConnectionUUID());
 			leastBusySlave.accept(job);
 		}
+		//if not registered anymore
 		else {
+			//try again
 			sendToLeastBusySlave(job);
 		}
 	}

--- a/src/main/java/io/github/incplusplus/peerprocessing/slave/Slave.java
+++ b/src/main/java/io/github/incplusplus/peerprocessing/slave/Slave.java
@@ -126,6 +126,7 @@ public class Slave implements ProperClient, Personable {
 		boolean notAlreadyClosed = running.compareAndSet(true, false);
 		assert notAlreadyClosed;
 		outToServer.println(DISCONNECT);
+		outToServer.flush();
 		kill();
 	}
 	

--- a/src/main/java/io/github/incplusplus/peerprocessing/slave/Slave.java
+++ b/src/main/java/io/github/incplusplus/peerprocessing/slave/Slave.java
@@ -63,7 +63,7 @@ public class Slave implements ProperClient, Personable {
 			enable();
 	}
 	
-	public boolean isClosed() {
+	public synchronized boolean isClosed() {
 		return !running.get();
 	}
 	
@@ -79,7 +79,7 @@ public class Slave implements ProperClient, Personable {
 	 * Begin reading or writing as expected.
 	 */
 	@Override
-	public void begin() {
+	public synchronized void begin() {
 		boolean firstStart = running.compareAndSet(false, true);
 		assert firstStart;
 		dealWithServer();
@@ -111,7 +111,7 @@ public class Slave implements ProperClient, Personable {
 	 * @throws IOException if an I/O error occurs
 	 */
 	@Override
-	public void close() throws IOException {
+	public synchronized void close() throws IOException {
 		boolean notAlreadyClosed = running.compareAndSet(true, false);
 		assert notAlreadyClosed;
 		outToServer.println(DISCONNECT);

--- a/src/main/java/io/github/incplusplus/peerprocessing/slave/Slave.java
+++ b/src/main/java/io/github/incplusplus/peerprocessing/slave/Slave.java
@@ -126,7 +126,6 @@ public class Slave implements ProperClient, Personable {
 		boolean notAlreadyClosed = running.compareAndSet(true, false);
 		assert notAlreadyClosed;
 		outToServer.println(DISCONNECT);
-		outToServer.flush();
 		kill();
 	}
 	

--- a/src/test/java/io/github/incplusplus/peerprocessing/QueryProcessingReassignmentIT.java
+++ b/src/test/java/io/github/incplusplus/peerprocessing/QueryProcessingReassignmentIT.java
@@ -1,0 +1,56 @@
+package io.github.incplusplus.peerprocessing;
+
+import io.github.incplusplus.peerprocessing.client.Client;
+import io.github.incplusplus.peerprocessing.linear.BigDecimalMatrix;
+import io.github.incplusplus.peerprocessing.server.Server;
+import io.github.incplusplus.peerprocessing.slave.Slave;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.FutureTask;
+
+import static io.github.incplusplus.peerprocessing.SingleSlaveIT.VERBOSE_TEST_OUTPUT;
+import static io.github.incplusplus.peerprocessing.linear.BigDecimalMatrixTest.iterateAndAssertEquals;
+
+public class QueryProcessingReassignmentIT {
+  private static int serverPort;
+  private static final Server server = new Server();
+
+  @BeforeAll
+  static void setUp() throws IOException {
+    serverPort = server.start(0, VERBOSE_TEST_OUTPUT);
+    //noinspection StatementWithEmptyBody
+    while (!server.started()) {}
+  }
+
+  @AfterAll
+  static void tearDown() throws IOException {
+    server.stop();
+  }
+
+  @ParameterizedTest
+  @MethodSource("io.github.incplusplus.peerprocessing.SingleSlaveIT#provideMatrices")
+  void whenSlaveDisconnects_IfSlaveHeldJobs_ThenJobsGetReassigned(BigDecimalMatrix matrix1, BigDecimalMatrix matrix2) throws IOException, ExecutionException, InterruptedException {
+    FutureTask<BigDecimalMatrix> task;
+    try (Client myClient = new Client("localhost", serverPort);
+         Slave mySlave = new Slave("localhost", serverPort)) {
+      myClient.setVerbose(VERBOSE_TEST_OUTPUT);
+      myClient.init();
+      myClient.begin();
+      mySlave.setVerbose(VERBOSE_TEST_OUTPUT);
+      mySlave.init();
+      mySlave.begin();
+      task = myClient.multiply(matrix1,matrix2);
+      ExecutorService executor = Executors.newFixedThreadPool(2);
+      executor.submit(task);
+      iterateAndAssertEquals(task.get(),matrix1.multiply(matrix2));
+//      task.get();
+    }
+  }
+}

--- a/src/test/java/io/github/incplusplus/peerprocessing/QueryProcessingReassignmentIT.java
+++ b/src/test/java/io/github/incplusplus/peerprocessing/QueryProcessingReassignmentIT.java
@@ -6,19 +6,21 @@ import io.github.incplusplus.peerprocessing.server.Server;
 import io.github.incplusplus.peerprocessing.slave.Slave;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Timeout;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.FutureTask;
+import java.util.concurrent.*;
 
 import static io.github.incplusplus.peerprocessing.SingleSlaveIT.VERBOSE_TEST_OUTPUT;
 import static io.github.incplusplus.peerprocessing.linear.BigDecimalMatrixTest.iterateAndAssertEquals;
+import static io.github.incplusplus.peerprocessing.logger.StupidSimpleLogger.debug;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-public class QueryProcessingReassignmentIT {
+@Timeout(value = 5, unit = TimeUnit.MINUTES)
+class QueryProcessingReassignmentIT {
   private static int serverPort;
   private static final Server server = new Server();
 
@@ -38,8 +40,8 @@ public class QueryProcessingReassignmentIT {
   @MethodSource("io.github.incplusplus.peerprocessing.SingleSlaveIT#provideMatrices")
   void whenSlaveDisconnects_IfSlaveHeldJobs_ThenJobsGetReassigned(BigDecimalMatrix matrix1, BigDecimalMatrix matrix2) throws IOException, ExecutionException, InterruptedException {
     FutureTask<BigDecimalMatrix> task;
-    try (Client myClient = new Client("localhost", serverPort);
-         Slave mySlave = new Slave("localhost", serverPort)) {
+    try (Client myClient = new Client("localhost", serverPort)) {
+      Slave mySlave = new Slave("localhost", serverPort);
       myClient.setVerbose(VERBOSE_TEST_OUTPUT);
       myClient.init();
       myClient.begin();
@@ -47,10 +49,39 @@ public class QueryProcessingReassignmentIT {
       mySlave.init();
       mySlave.begin();
       task = myClient.multiply(matrix1,matrix2);
+      while (!myClient.isPolite()){}
+      while (!mySlave.isPolite()){}
       ExecutorService executor = Executors.newFixedThreadPool(2);
       executor.submit(task);
-      iterateAndAssertEquals(task.get(),matrix1.multiply(matrix2));
-//      task.get();
+      mySlave.disconnect();
+      Thread thread = new Thread(() -> {
+        try {
+          task.get();
+          //we should never get here
+          assert false;
+        } catch (InterruptedException ignored) {
+          //we intend to interrupt this thread
+          debug("Execution waiting thread interrupted as normal.");
+        }
+        catch (ExecutionException e) {
+          //fail
+          assert false;
+        }
+      });
+      thread.start();
+      //Let the current thread sleep (not the created thread!)
+      Thread.sleep(5000);
+      assertTrue(thread.isAlive());
+      assertFalse(task.isDone());
+      mySlave = new Slave("localhost", serverPort);
+      mySlave.setVerbose(VERBOSE_TEST_OUTPUT);
+      mySlave.init();
+      thread.interrupt();
+      mySlave.begin();
+      while (!mySlave.isPolite()){}
+      task.get();
+      executor.shutdown();
+      mySlave.disconnect();
     }
   }
 }

--- a/src/test/java/io/github/incplusplus/peerprocessing/server/QueryProcessingReassignmentIT.java
+++ b/src/test/java/io/github/incplusplus/peerprocessing/server/QueryProcessingReassignmentIT.java
@@ -1,4 +1,4 @@
-package io.github.incplusplus.peerprocessing;
+package io.github.incplusplus.peerprocessing.server;
 
 import io.github.incplusplus.peerprocessing.client.Client;
 import io.github.incplusplus.peerprocessing.linear.BigDecimalMatrix;

--- a/src/test/java/io/github/incplusplus/peerprocessing/server/QueryProcessingReassignmentIT.java
+++ b/src/test/java/io/github/incplusplus/peerprocessing/server/QueryProcessingReassignmentIT.java
@@ -54,7 +54,7 @@ class QueryProcessingReassignmentIT {
       ExecutorService executor = Executors.newFixedThreadPool(2);
       executor.submit(task);
       //At this point, the slave should be dealing with some tasks
-      Thread.sleep(100);
+      Thread.sleep(2000);
       mySlave.disconnect();
       //noinspection StatementWithEmptyBody
       while (!mySlave.isClosed()) {}

--- a/src/test/java/io/github/incplusplus/peerprocessing/server/QueryProcessingReassignmentIT.java
+++ b/src/test/java/io/github/incplusplus/peerprocessing/server/QueryProcessingReassignmentIT.java
@@ -43,10 +43,8 @@ class QueryProcessingReassignmentIT {
     try (Client myClient = new Client("localhost", serverPort)) {
       Slave mySlave = new Slave("localhost", serverPort);
       myClient.setVerbose(VERBOSE_TEST_OUTPUT);
-      myClient.init();
       myClient.begin();
       mySlave.setVerbose(VERBOSE_TEST_OUTPUT);
-      mySlave.init();
       mySlave.begin();
       task = myClient.multiply(matrix1,matrix2);
       //noinspection StatementWithEmptyBody
@@ -82,7 +80,6 @@ class QueryProcessingReassignmentIT {
       assertFalse(task.isDone());
       mySlave = new Slave("localhost", serverPort);
       mySlave.setVerbose(VERBOSE_TEST_OUTPUT);
-      mySlave.init();
       thread.interrupt();
       mySlave.begin();
       //noinspection StatementWithEmptyBody

--- a/src/test/java/io/github/incplusplus/peerprocessing/server/QueryProcessingReassignmentIT.java
+++ b/src/test/java/io/github/incplusplus/peerprocessing/server/QueryProcessingReassignmentIT.java
@@ -49,13 +49,15 @@ class QueryProcessingReassignmentIT {
       mySlave.init();
       mySlave.begin();
       task = myClient.multiply(matrix1,matrix2);
+      //noinspection StatementWithEmptyBody
       while (!myClient.isPolite()){}
+      //noinspection StatementWithEmptyBody
       while (!mySlave.isPolite()){}
       ExecutorService executor = Executors.newFixedThreadPool(2);
       executor.submit(task);
       //wait until the slave is responsible for some tasks
       //noinspection StatementWithEmptyBody
-      while(server.slaves.get(mySlave.getConnectionId()).getJobsResponsibleFor().size()<1) {}
+      while(server.slaves.get(mySlave.getConnectionId()).getJobsResponsibleFor().size()<5) {}
       mySlave.disconnect();
       Thread thread = new Thread(() -> {
         try {

--- a/src/test/java/io/github/incplusplus/peerprocessing/server/QueryProcessingReassignmentIT.java
+++ b/src/test/java/io/github/incplusplus/peerprocessing/server/QueryProcessingReassignmentIT.java
@@ -53,6 +53,9 @@ class QueryProcessingReassignmentIT {
       while (!mySlave.isPolite()){}
       ExecutorService executor = Executors.newFixedThreadPool(2);
       executor.submit(task);
+      //wait until the slave is responsible for some tasks
+      //noinspection StatementWithEmptyBody
+      while(server.slaves.get(mySlave.getConnectionId()).getJobsResponsibleFor().size()<1) {}
       mySlave.disconnect();
       Thread thread = new Thread(() -> {
         try {

--- a/src/test/java/io/github/incplusplus/peerprocessing/server/QueryProcessingReassignmentIT.java
+++ b/src/test/java/io/github/incplusplus/peerprocessing/server/QueryProcessingReassignmentIT.java
@@ -66,7 +66,7 @@ class QueryProcessingReassignmentIT {
       }
       //noinspection StatementWithEmptyBody
       while (!mySlave.isClosed()) {}
-      System.out.println("Slave is now closed!");
+      Thread.sleep(50);
       Thread thread =
           new Thread(
               () -> {

--- a/src/test/java/io/github/incplusplus/peerprocessing/server/QueryProcessingReassignmentIT.java
+++ b/src/test/java/io/github/incplusplus/peerprocessing/server/QueryProcessingReassignmentIT.java
@@ -66,6 +66,7 @@ class QueryProcessingReassignmentIT {
       }
       //noinspection StatementWithEmptyBody
       while (!mySlave.isClosed()) {}
+      //If this test hangs up the build, change this to 100. That shouldn't happen though
       Thread.sleep(50);
       Thread thread =
           new Thread(

--- a/src/test/java/io/github/incplusplus/peerprocessing/server/QueryProcessingReassignmentIT.java
+++ b/src/test/java/io/github/incplusplus/peerprocessing/server/QueryProcessingReassignmentIT.java
@@ -59,6 +59,8 @@ class QueryProcessingReassignmentIT {
       //noinspection StatementWithEmptyBody
       while(server.slaves.get(mySlave.getConnectionId()).getJobsResponsibleFor().size()<5) {}
       mySlave.disconnect();
+      //noinspection StatementWithEmptyBody
+      while (mySlave.isClosed()) {}
       Thread thread = new Thread(() -> {
         try {
           task.get();

--- a/src/test/java/io/github/incplusplus/peerprocessing/server/QueryProcessingReassignmentIT.java
+++ b/src/test/java/io/github/incplusplus/peerprocessing/server/QueryProcessingReassignmentIT.java
@@ -53,9 +53,8 @@ class QueryProcessingReassignmentIT {
       while (!mySlave.isPolite()){}
       ExecutorService executor = Executors.newFixedThreadPool(2);
       executor.submit(task);
-      //wait until the slave is responsible for some tasks
-      //noinspection StatementWithEmptyBody
-      while(server.slaves.get(mySlave.getConnectionId()).getJobsResponsibleFor().size()<5) {}
+      //At this point, the slave should be dealing with some tasks
+      Thread.sleep(100);
       mySlave.disconnect();
       //noinspection StatementWithEmptyBody
       while (!mySlave.isClosed()) {}

--- a/src/test/java/io/github/incplusplus/peerprocessing/server/QueryProcessingReassignmentIT.java
+++ b/src/test/java/io/github/incplusplus/peerprocessing/server/QueryProcessingReassignmentIT.java
@@ -66,6 +66,7 @@ class QueryProcessingReassignmentIT {
       }
       //noinspection StatementWithEmptyBody
       while (!mySlave.isClosed()) {}
+      System.out.println("Slave is now closed!");
       Thread thread =
           new Thread(
               () -> {

--- a/src/test/java/io/github/incplusplus/peerprocessing/server/QueryProcessingReassignmentIT.java
+++ b/src/test/java/io/github/incplusplus/peerprocessing/server/QueryProcessingReassignmentIT.java
@@ -83,6 +83,7 @@ class QueryProcessingReassignmentIT {
       mySlave.init();
       thread.interrupt();
       mySlave.begin();
+      //noinspection StatementWithEmptyBody
       while (!mySlave.isPolite()){}
       task.get();
       executor.shutdown();

--- a/src/test/java/io/github/incplusplus/peerprocessing/server/QueryProcessingReassignmentIT.java
+++ b/src/test/java/io/github/incplusplus/peerprocessing/server/QueryProcessingReassignmentIT.java
@@ -60,7 +60,7 @@ class QueryProcessingReassignmentIT {
       while(server.slaves.get(mySlave.getConnectionId()).getJobsResponsibleFor().size()<5) {}
       mySlave.disconnect();
       //noinspection StatementWithEmptyBody
-      while (mySlave.isClosed()) {}
+      while (!mySlave.isClosed()) {}
       Thread thread = new Thread(() -> {
         try {
           task.get();

--- a/src/test/java/io/github/incplusplus/peerprocessing/server/QueryProcessingReassignmentIT.java
+++ b/src/test/java/io/github/incplusplus/peerprocessing/server/QueryProcessingReassignmentIT.java
@@ -27,7 +27,7 @@ class QueryProcessingReassignmentIT {
 
   @BeforeAll
   static void setUp() throws IOException {
-    serverPort = server.start(INITIAL_SERVER_PORT, VERBOSE_TEST_OUTPUT);
+    serverPort = server.start(9999, VERBOSE_TEST_OUTPUT);
     //noinspection StatementWithEmptyBody
     while (!server.started()) {}
   }


### PR DESCRIPTION
If a slave disconnects while the server expects it to be evaluating queries, it would be a logical decision for the server to reassign the jobs the slave was responsible for to the remaining slaves. This PR accomplishes this task.