### PR TITLE
Fix slave responsible query IDs being corrupted

### DIFF
--- a/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
+++ b/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
@@ -476,7 +476,7 @@ public class Server {
 	}
 	
 	class SlaveObj extends ConnectedEntity {
-		private final List<UUID> jobsResponsibleFor = new ArrayList<>();
+		private final List<UUID> jobsResponsibleFor = Collections.synchronizedList(new ArrayList<>());
 		
 		SlaveObj(PrintWriter outToClient, BufferedReader inFromClient, Socket socket,
 		         UUID connectionUUID) {super(outToClient, inFromClient, socket, connectionUUID);}

--- a/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
+++ b/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
@@ -515,7 +515,8 @@ public class Server {
 						storedQuery.setResult(completedQuery.getResult());
 						storedQuery.setCompleted(true);
 						submitCompletedJob(storedQuery);
-						jobsResponsibleFor.remove(storedQuery.getQueryId());
+						boolean definitelyShouldStillPossessJob = jobsResponsibleFor.remove(storedQuery.getQueryId());
+						assert definitelyShouldStillPossessJob;
 					}
 					else if (header.equals(IDENTIFY)) {
 						getOutToClient().println(


### PR DESCRIPTION
Inside the server's representation of a slave connection, (`SlaveObj`), there is a list of UUIDs representing the queries that slave is responsible for evaluating. Sometimes, the get operation on this list would return null. This PR fixes that issue.