### PR TITLE
Fix early CodeCov PR notifs

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,4 +1,6 @@
 coverage:
+  notify:
+    after_n_builds: 4
   status:
     project:
       unittests:


### PR DESCRIPTION
The number of builds should actually be 2 but since we upload twice for each, it considers it to be 4 builds... I think...

This PR changes the build threshold to be 4.