### PR TITLE
Fix broken job assignment logic

### DIFF
--- a/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
+++ b/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
@@ -385,15 +385,15 @@ public class Server {
 						debug("Job ingestion thread ate a poison pill and is shutting down.");
 						break;
 					}
-					if(currentJob instanceof AlgebraicQuery) {
-						sendToLeastBusySlave(currentJob);
-					}
 					if(currentJob instanceof BatchQuery) {
 						currentJob.setQueryState(WAITING_ON_SLAVE);
 						for(Query individualJob : ((BatchQuery) currentJob).getQueries()) {
 							queries.put(individualJob.getQueryId(),individualJob);
-							sendToLeastBusySlave(individualJob);
+							jobsAwaitingProcessing.add(individualJob);
 						}
+					}
+					else {
+						sendToLeastBusySlave(currentJob);
 					}
 				}
 				catch (InterruptedException | JsonProcessingException e) {


### PR DESCRIPTION
When I implemented the batch processing functionality, I should have just added the jobs to the queue again for processing. Instead, I used a cheap hack to send them immediately. This caused hangups if jobs are added to the list for pending jobs because they are never dealt with.