### PR TITLE
Do fewer random multiplication tests

### DIFF
--- a/src/test/java/io/github/incplusplus/peerprocessing/linear/BigDecimalMatrixTest.java
+++ b/src/test/java/io/github/incplusplus/peerprocessing/linear/BigDecimalMatrixTest.java
@@ -106,7 +106,7 @@ public class BigDecimalMatrixTest {
     assertFalse(dumb4x3.isSquare());
   }
 
-  @RepeatedTest(10)
+  @RepeatedTest(4)
   void randomMultiplicationTest() {
     int aRows = randInt(100, 1000);
     int aColsAndBRows = randInt(100, 1000);


### PR DESCRIPTION
This won't change coverage or reliability but will improve test runtime.