### PR TITLE
Potentially improve assignment performance

### DIFF
--- a/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
+++ b/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
@@ -369,9 +369,8 @@ public class Server {
     synchronized (slaves) {
       leastBusySlave =
           slaves
-              .entrySet()
-              .parallelStream()
-              .map(Map.Entry::getValue)
+              .values()
+              .stream()
               // find the slave that is responsible for the fewest jobs
               .min(Comparator.comparingInt(slaveObj -> slaveObj.getJobsResponsibleFor().size()))
               // get the actual SlaveObj or else

--- a/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
+++ b/src/main/java/io/github/incplusplus/peerprocessing/server/Server.java
@@ -368,9 +368,7 @@ public class Server {
     // just because it's a ConcurrentHashMap doesn't mean everything is safe!
     synchronized (slaves) {
       leastBusySlave =
-          slaves
-              .values()
-              .stream()
+          slaves.values().stream()
               // find the slave that is responsible for the fewest jobs
               .min(Comparator.comparingInt(slaveObj -> slaveObj.getJobsResponsibleFor().size()))
               // get the actual SlaveObj or else


### PR DESCRIPTION
Don't explicitly use parallelStream and grab the values directly instead of mapping getValue() over the entry set.