### PR TITLE
Ensure the warning branch is covered

### DIFF
--- a/src/test/java/io/github/incplusplus/peerprocessing/client/ClientTest.java
+++ b/src/test/java/io/github/incplusplus/peerprocessing/client/ClientTest.java
@@ -1,14 +1,30 @@
 package io.github.incplusplus.peerprocessing.client;
 
+import static io.github.incplusplus.peerprocessing.NormalIT.VERBOSE_TEST_OUTPUT;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import io.github.incplusplus.peerprocessing.server.Server;
+import java.io.IOException;
 import org.junit.jupiter.api.Test;
 
 class ClientTest {
 
-  @Test()
+  @Test
   void failIfNoServer() {
     Client myClient = new Client("localhost", 9999);
     assertThrows(java.net.ConnectException.class, myClient::begin);
+  }
+
+  @Test
+  void ensureWarningBranchCovered() throws IOException {
+    Server server = new Server();
+    int port = server.start(0, VERBOSE_TEST_OUTPUT);
+    Client myClient = new Client("localhost", port);
+    myClient.begin();
+    //noinspection StatementWithEmptyBody
+    while (!myClient.isPolite()) {}
+    myClient.close();
+    // close again to make sure the other branch is covered
+    myClient.close();
   }
 }


### PR DESCRIPTION
This should resolve the inconsistent coverage as seen in https://codecov.io/gh/IncPlusPlus/NetProgFinalProject/src/de18c879dc3b265364a640c08dff289f78fd8af7/src/main/java/io/github/incplusplus/peerprocessing/client/Client.java#L125